### PR TITLE
Intent Router Logging

### DIFF
--- a/.clabot
+++ b/.clabot
@@ -1,4 +1,4 @@
 {
-  "contributors": ["ZanSara"],
+  "contributors": ["ZanSara", "fjprobos"],
   "message": "Thank you for your pull request and welcome to our community. We require contributors to sign our Contributor License Agreement, and we don't seem to have the users {{usersWithoutCLA}} on file. In order for us to review and merge your code, please contact the project maintainers to get yourself added.\nAlternatively, you can add yourself to the list by editing the `.clabot` file in the root of this repository. Adding yourself to the list implies that you agree to the terms of the Contributor License Agreement, which you can review [here](https://intentional-ai.github.io/intentional/docs/cla/)."
 }

--- a/intentional-core/src/intentional_core/intent_routing.py
+++ b/intentional-core/src/intentional_core/intent_routing.py
@@ -137,6 +137,23 @@ class IntentRouter(Tool):
         selected_outcome = params["outcome"]
         transitions = self.get_external_transitions()
         origin_stage = self.current_stage_name
+        next_stage = None
+        transition_type = None
+        last_user_message = params.get("last_user_message", None)
+
+        log.info(
+            "Evaluating transition",
+            current_stage=self.current_stage_name,
+            current_goal=self.current_stage.goal,
+            available_outcomes=list(self.current_stage.outcomes.keys()),
+            available_transitions=transitions,
+            selected_outcome=selected_outcome,
+            last_user_message=(
+                last_user_message
+                if last_user_message
+                else "Last user message not reported for transition loging purposes."
+            ),
+        )
 
         if selected_outcome not in self.current_stage.outcomes and selected_outcome not in transitions:
             raise ValueError(f"Unknown outcome '{params['outcome']}' for stage '{self.current_stage_name}'")
@@ -146,16 +163,29 @@ class IntentRouter(Tool):
 
             if next_stage != BACKTRACKING_CONNECTION:
                 # Direct stage to stage connection
+                transition_type = "direct"
                 self.current_stage_name = next_stage
             else:
                 # Backtracking connection
+                transition_type = "backtrack"
                 self.current_stage_name = self.backtracking_stack.pop()
+                next_stage = self.current_stage_name
         else:
             # Indirect transition, needs to be tracked in the stack
+            transition_type = "external"
             self.backtracking_stack.append(self.current_stage_name)
             self.current_stage_name = selected_outcome
+            next_stage = selected_outcome
 
-        log.info("Moving from stage", original_stage=origin_stage, destination_stage=self.current_stage_name)
+        log.info(
+            "Transition details: ",
+            original_stage=origin_stage,
+            destination_stage=self.current_stage_name,
+            transition_type=transition_type,
+            outcome_selected=selected_outcome,
+            backtrack_stack_size=len(self.backtracking_stack),
+        )
+
         return self.get_prompt(), self.current_stage.tools
 
     def get_prompt(self):

--- a/intentional-core/src/intentional_core/intent_routing.py
+++ b/intentional-core/src/intentional_core/intent_routing.py
@@ -136,6 +136,7 @@ class IntentRouter(Tool):
         """
         selected_outcome = params["outcome"]
         transitions = self.get_external_transitions()
+        origin_stage = self.current_stage_name
 
         if selected_outcome not in self.current_stage.outcomes and selected_outcome not in transitions:
             raise ValueError(f"Unknown outcome '{params['outcome']}' for stage '{self.current_stage_name}'")
@@ -154,6 +155,7 @@ class IntentRouter(Tool):
             self.backtracking_stack.append(self.current_stage_name)
             self.current_stage_name = selected_outcome
 
+        log.info("Moving from stage", original_stage=origin_stage, destination_stage=self.current_stage_name)
         return self.get_prompt(), self.current_stage.tools
 
     def get_prompt(self):

--- a/plugins/intentional-openai/src/intentional_openai/chatcompletion_api.py
+++ b/plugins/intentional-openai/src/intentional_openai/chatcompletion_api.py
@@ -184,6 +184,8 @@ class ChatCompletionAPIClient(LLMClient):
 
         # Routing function call - this is special because it should not be recorded in the conversation history
         if function_name == self.intent_router.name:
+            log.info("Routing function call, selected_outcome", selected_outcome=function_args.get("outcome", "no outcome selected"))
+            log.info("Outcome selected given content from role", input=message.get("content", "no input"), role=message.get("role", "no role"))
             await self._route(function_args)
             # Send the same message again with the new system prompt and no trace of the routing call.
             # We don't append the user message to the history in order to avoid message duplication.

--- a/plugins/intentional-openai/src/intentional_openai/chatcompletion_api.py
+++ b/plugins/intentional-openai/src/intentional_openai/chatcompletion_api.py
@@ -184,8 +184,7 @@ class ChatCompletionAPIClient(LLMClient):
 
         # Routing function call - this is special because it should not be recorded in the conversation history
         if function_name == self.intent_router.name:
-            log.info("Routing function call, selected_outcome", selected_outcome=function_args.get("outcome", "no outcome selected"))
-            log.info("Outcome selected given content from role", input=message.get("content", "no input"), role=message.get("role", "no role"))
+            function_args["last_user_message"] = message.get("content", "no input")
             await self._route(function_args)
             # Send the same message again with the new system prompt and no trace of the routing call.
             # We don't append the user message to the history in order to avoid message duplication.


### PR DESCRIPTION
Closes #51

## Changes
This PR adds detailed logging to the Intent Router to improve the visibility of routing decisions and transitions between stages. New logging includes:

- Origin and destination stages for each transition
- Selected outcome
- Last message from the user considered in reasoning

